### PR TITLE
Add ImportBlendShapesDisabler script

### DIFF
--- a/Scripts/Editor/ImportBlendShapesDisabler.cs
+++ b/Scripts/Editor/ImportBlendShapesDisabler.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+public class ImportBlendShapesDisabler : AssetPostprocessor
+{
+    private const string NoBlendShapesFolder = "NoBlendShapes";
+
+    private void OnPreprocessModel()
+    {
+        if(assetPath.Contains("NoBlendShapes"))
+        {
+            var modelImporter = assetImporter as ModelImporter;
+
+            if(modelImporter.importBlendShapes)
+            {
+                var assetName = Path.GetFileNameWithoutExtension(assetPath);
+                Debug.LogWarning(
+                    $"[{assetName}]: Blendshapes are disabled in paths containing [{NoBlendShapesFolder}].");
+                modelImporter.importBlendShapes = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Import BlendShapes Disabler (Asset Post Processor)

## Summary  
This PR adds an `AssetPostprocessor` script that ensures "Import BlendShapes" is always disabled for model assets imported into a specific folder. 

## What's Included

### `ImportBlendShapesDisabler.cs`
- A Unity Editor script using `AssetPostprocessor`
- Automatically disables `importBlendShapes` in `ModelImporter` settings
- Only runs on assets imported into folders matching a specific path (_note:_ currently hardcoded in a `private const string` to `"Assets/Models/NoBlendShapes"` — this can be changed in the script)
- To use, place model files inside the designated folder, and they will automatically import with blendshapes disabled
- If the user tries to enable blendshapes in the Inspector, the script will disable the setting again.

## Testing  
Basic testing was performed by importing `.fbx` files into the target folder. Upon import, blendshapes were correctly disabled in the Model Import Settings.

### Notes
The script and this PR are for learning purposes; it has not been thoroughly tested :)
